### PR TITLE
create locations, regions, rules, connections

### DIFF
--- a/worlds/dk64/Logic.py
+++ b/worlds/dk64/Logic.py
@@ -1,5 +1,7 @@
 """Contains the class which holds logic variables, and the master copy of regions."""
 from math import ceil
+from typing import List
+from BaseClasses import CollectionState
 
 import dk64r.randomizer.CollectibleLogicFiles.AngryAztec
 import dk64r.randomizer.CollectibleLogicFiles.CreepyCastle
@@ -48,10 +50,10 @@ from dk64r.randomizer.Enums.Time import Time
 from dk64r.randomizer.Enums.Types import Types
 from dk64r.randomizer.Lists.Item import ItemList
 from dk64r.randomizer.Enums.Maps import Maps
-from dk64r.randomizer.Lists.ShufflableExit import GetShuffledLevelIndex
 from dk64r.randomizer.Lists.Warps import BananaportVanilla
 from dk64r.randomizer.Patching.Lib import IsItemSelected
-from dk64r.randomizer.Prices import AnyKongCanBuy, CanBuy, GetPriceAtLocation
+from dk64r.randomizer.Prices import AnyKongCanBuy, CanBuy
+from worlds.dk64.Items import DK64Item
 
 STARTING_SLAM = 0  # Currently we're assuming you always start with 1 slam
 
@@ -307,6 +309,18 @@ class LogicVarHolder:
         """Update coin total."""
         for x in range(5):
             self.Coins[x] = (self.RegularCoins[x] + (5 * self.RainbowCoins)) - self.SpentCoins[x]
+
+    def UpdateFromArchipelagoItems(self, collectionState: CollectionState, archItems: List[DK64Item]):
+        """Update logic variables based on the DK64Items found by Archipelago."""
+        self.Reset()
+        ownedItems = []
+        for item_name, item_count in collectionState.prog_items[self.world.player].items():
+            corresponding_item = [item for item in ItemList.values() if item.name == item_name]
+            for i in range(item_count):
+                ownedItems.append(corresponding_item)
+        for item in archItems:
+            ownedItems.append(item.dk64_id)
+        self.Update(ownedItems)
 
     def Update(self, ownedItems):
         """Update logic variables based on owned items."""

--- a/worlds/dk64/Regions.py
+++ b/worlds/dk64/Regions.py
@@ -1,15 +1,12 @@
 import typing
 
-from BaseClasses import MultiWorld, Region, Entrance, Location
+from BaseClasses import CollectionState, MultiWorld, Region, Entrance, Location
 from worlds.AutoWorld import World
-from dk64r.randomizer.Lists import Item as DK64RItem
-from dk64r.randomizer.Enums.Items import Items as DK64RItems
 
 from dk64r.randomizer.Lists import Location as DK64RLocation
-from dk64r.randomizer.Enums.Locations import Locations as DK64RLocations
+from dk64r.randomizer.LogicClasses import LocationLogic, TransitionFront
+from worlds.generic.Rules import set_rule
 from .Logic import LogicVarHolder
-from dk64r.randomizer.Spoiler import Spoiler
-from dk64r.randomizer.Settings import Settings
 from dk64r.randomizer.LogicFiles import (
     AngryAztec,
     CreepyCastle,
@@ -39,24 +36,8 @@ all_locations.update({"Victory": 0x00})  # Temp for generating goal location
 lookup_id_to_name: typing.Dict[int, str] = {id: name for name, id in all_locations.items()}
 
 
-def create_regions(multiworld: MultiWorld, player: int):
-    menu_region = create_region(multiworld, player, "Menu")
-    test_region = create_region(multiworld, player, "Test", ["Victory"])
-
-    multiworld.regions += [
-        menu_region,
-        test_region,
-    ]
-
-    def _logic_region(GroupedRegion):
-        for location in GroupedRegion:
-            location_list = []
-            region_obj = GroupedRegion[location]
-            for loc in region_obj.locations:
-                location_list.append(loc.id.name)
-            multiworld.regions.append(create_region(multiworld, player, location.name, location_list))
-
-    for region in [
+def create_regions(multiworld: MultiWorld, player: int, logic_holder: LogicVarHolder):    
+    for level_regions in [
         AngryAztec.LogicRegions,
         CreepyCastle.LogicRegions,
         CrystalCaves.LogicRegions,
@@ -68,19 +49,26 @@ def create_regions(multiworld: MultiWorld, player: int):
         GloomyGalleon.LogicRegions,
         Shops.LogicRegions,
     ]:
-        _logic_region(region)
+        for region_id in level_regions:
+            location_logics = []
+            region_obj = level_regions[region_id]
+            for loc in region_obj.locations:
+                if not loc.isAuxiliaryLocation:
+                    location_logics.append(loc)
+            multiworld.regions.append(create_region(multiworld, player, region_obj.name, location_logics, logic_holder))
 
 
-def create_region(multiworld: MultiWorld, player: int, name: str, locations=None) -> Region:
+def create_region(multiworld: MultiWorld, player: int, name: str, location_logics: typing.List[LocationLogic], logic_holder: LogicVarHolder) -> Region:
     new_region = Region(name, player, multiworld)
-    if locations:
-        for location_name in locations:
+    if location_logics:
+        for location_logic in location_logics:
+            location_name = DK64RLocation.LocationListOriginal[location_logic.id].name
             loc_id = all_locations.get(location_name, 0)
-
             location = DK64Location(player, location_name, loc_id, new_region)
+            set_rule(location, lambda state: hasDK64RLocation(state, logic_holder, location_logic))
             new_region.locations.append(location)
-
     return new_region
+
 
 def connect_regions(world: World, logic_holder: LogicVarHolder):
     # connect(world, "Menu", "DK Isles")
@@ -93,9 +81,7 @@ def connect_regions(world: World, logic_holder: LogicVarHolder):
     #     lambda state: state.has(DK64RItem.ItemList[DK64RItems.GoldenBanana].name, world.player, 2),
     # )
 
-    # DK64_TODO: Get region access requirements from DK64R
-
-    for region in [
+    for region_list in [
         AngryAztec.LogicRegions,
         CreepyCastle.LogicRegions,
         CrystalCaves.LogicRegions,
@@ -107,12 +93,12 @@ def connect_regions(world: World, logic_holder: LogicVarHolder):
         GloomyGalleon.LogicRegions,
         Shops.LogicRegions,
     ]:
-        for location in region:
-            region_obj = region[location]
-            for loc in region_obj.locations:
+        for region_obj in region_list.values():
+            for exit in region_obj.exits:
+                destination = region_list[exit.dest]
                 try:
-                    converted_logic = lambda state: loc.logic(logic_holder)
-                    connect(world, location.name, loc.id.name, converted_logic)
+                    converted_logic = lambda state: hasDK64RTransition(state, logic_holder, exit)
+                    connect(world, region_obj.name, destination.name, converted_logic)
                 except Exception:
                     pass
     pass
@@ -131,3 +117,13 @@ def connect(world: World, source: str, target: str, rule: typing.Optional[typing
 
     source_region.exits.append(connection)
     connection.connect(target_region)
+
+
+def hasDK64RTransition(state: CollectionState, logic: LogicVarHolder, exit: TransitionFront):
+    logic.UpdateFromArchipelagoItems(state)
+    return exit.logic(logic)
+
+
+def hasDK64RLocation(state: CollectionState, logic: LogicVarHolder, location: LocationLogic):
+    logic.UpdateFromArchipelagoItems(state)
+    return location.logic(logic)

--- a/worlds/dk64/Rules.py
+++ b/worlds/dk64/Rules.py
@@ -9,4 +9,4 @@ def set_rules(world: MultiWorld, player: int):
 
     # DK64_TODO: Get location access rules from DK64R
 
-    world.completion_condition[player] = lambda state: state.has("Victory", player) # Temp
+    world.completion_condition[player] = lambda state: state.has("Banana Hoard", player)

--- a/worlds/dk64/__init__.py
+++ b/worlds/dk64/__init__.py
@@ -73,14 +73,14 @@ class DK64World(World):
         pass
 
     def create_regions(self) -> None:
-        create_regions(self.multiworld, self.player)
+        create_regions(self.multiworld, self.player, self.logic_holder)
 
     def create_items(self) -> None:
         itempool: typing.List[DK64Item] = setup_items(self)
         self.multiworld.itempool += itempool
 
     def set_rules(self):
-        set_rules(self.multiworld, self.player)
+        set_rules(self.multiworld, self.player, self.logic_holder)
 
     def generate_basic(self):
         connect_regions(self, self.logic_holder)


### PR DESCRIPTION
Implemented a first stab at generic Location and Region creation, as well as generic location rules and connection rules. This is just getting a generic implementation in and doesn't cover any specifics. There's a couple notable spots that have to be hand-adjusted like level order. In addition, this does not consider the shuffled location types whatsoever and that'd be a significant addition.

Some questions that arose:
- We have some locations that are in multiple regions because you initialize a glitch to get the item from the first region. Is this manageable in Archipelago somehow?
- How do we handle constant items? I updated the Banana Hoard item to be our win condition because that's how we handle it, but how do we always place the Banana Hoard item on the Banana Hoard location every time?